### PR TITLE
Use an identifiable user-agent

### DIFF
--- a/amg/__init__.py
+++ b/amg/__init__.py
@@ -68,6 +68,7 @@ BANDCAMP_JS_SELECTOR = lxml.cssselect.CSSSelector("html > head > script")
 REVERBNATION_SCRIPT_SELECTOR = lxml.cssselect.CSSSelector("script")
 IS_TRAVIS = os.getenv("CI") and os.getenv("TRAVIS")
 TCP_TIMEOUT = 30.1 if IS_TRAVIS else 9.1
+USER_AGENT = "Mozilla/5.0 AMG-Player/{}".format(__version__)
 
 
 def fetch_page(url, *, http_cache=None):
@@ -77,7 +78,7 @@ def fetch_page(url, *, http_cache=None):
     page = http_cache[url]
   else:
     logging.getLogger().debug("Fetching '%s'..." % (url))
-    headers = {"User-Agent": "Mozilla/5.0"}
+    headers = {"User-Agent": USER_AGENT}
     response = requests.get(url, headers=headers, timeout=TCP_TIMEOUT)
     response.raise_for_status()
     page = response.content
@@ -89,7 +90,7 @@ def fetch_page(url, *, http_cache=None):
 def fetch_ressource(url, dest_filepath):
   """ Fetch ressource, and write it to file. """
   logging.getLogger().debug("Fetching '%s'..." % (url))
-  headers = {"User-Agent": "Mozilla/5.0"}
+  headers = {"User-Agent": ""}
   with contextlib.closing(requests.get(url, headers=headers, timeout=TCP_TIMEOUT, stream=True)) as response:
     response.raise_for_status()
     with open(dest_filepath, "wb") as dest_file:

--- a/amg/__init__.py
+++ b/amg/__init__.py
@@ -90,7 +90,7 @@ def fetch_page(url, *, http_cache=None):
 def fetch_ressource(url, dest_filepath):
   """ Fetch ressource, and write it to file. """
   logging.getLogger().debug("Fetching '%s'..." % (url))
-  headers = {"User-Agent": ""}
+  headers = {"User-Agent": USER_AGENT}
   with contextlib.closing(requests.get(url, headers=headers, timeout=TCP_TIMEOUT, stream=True)) as response:
     response.raise_for_status()
     with open(dest_filepath, "wb") as dest_file:


### PR DESCRIPTION
Hi - I'm the sysadmin at AMG. Firstly - this is a seriously cool project, and I'm really impressed.

This is a pretty minor change to use a slightly more identifiable user-agent (`Mozilla/5.0 AMG-Player/(version)`), mostly so I don't accidentally block it (`Mozilla/5.0` as the UA looks super weird). I've tested and it doesn't seem to be blocked by any of the services it's calling out to.